### PR TITLE
change the paths of the IAR toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: Continuous Integration (CI)
+on:
+  push:
+
+jobs:
+  ci:
+    runs-on: self-hosted
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,3 +7,18 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+
+      - run: |
+          echo "Check Compiler..."
+          /opt/iar/cxarm/arm/bin/iccarm --version
+        name: Check Compiler License and Version
+
+      - run: |
+          echo "Do CI..."
+          # Add your CI commands here
+          mkdir -p ./build
+          cd ./build
+          cmake .. -G Ninja --toolchain ../bxarm.cmake
+          cmake --build .
+        name: Run CMAKE
+        working-directory: ./tutorial

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Continuous Integration (CI)
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,5 @@ on:
 jobs:
   ci:
     runs-on: self-hosted
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ CMake uses the host platform's default compiler. When cross-compiling embedded a
 
 | Variable             | Description                               | Examples                                                                        |
 | -                    | -                                         | -                                                                               |
-| `CMAKE_C_COMPILER`   | Must point to the C Compiler executable   | `"C:/Program Files/..../arm/bin/iccarm.exe"`<br>`"/opt/iarsystems/bxarm/arm/bin/iccarm"`   |
-| `CMAKE_CXX_COMPILER` | Must point to the C++ Compiler executable | `"C:/Program Files/..../arm/bin/iccarm.exe"`<br>`"/opt/iarsystems/bxarm/arm/bin/iccarm"`   |
-| `CMAKE_ASM_COMPILER` | Must point to the Assembler executable    | `"C:/Program Files/..../arm/bin/iasmarm.exe"`<br>`"/opt/iarsystems/bxarm/arm/bin/iasmarm"` |
-| `CMAKE_MAKE_PROGRAM` | Must point to the build tool executable | `"C:/Program Files/..../common/bin/ninja.exe"`<br>`"/opt/iarsystems/bxarm/common/bin/ninja"` |
+| `CMAKE_C_COMPILER`   | Must point to the C Compiler executable   | `"C:/Program Files/..../arm/bin/iccarm.exe"`<br>`"/opt/iar/cxarm/arm/bin/iccarm"`   |
+| `CMAKE_CXX_COMPILER` | Must point to the C++ Compiler executable | `"C:/Program Files/..../arm/bin/iccarm.exe"`<br>`"/opt/iar/cxarm/arm/bin/iccarm"`   |
+| `CMAKE_ASM_COMPILER` | Must point to the Assembler executable    | `"C:/Program Files/..../arm/bin/iasmarm.exe"`<br>`"/opt/iar/cxarm/arm/bin/iasmarm"` |
+| `CMAKE_MAKE_PROGRAM` | Must point to the build tool executable | `"C:/Program Files/..../common/bin/ninja.exe"`<br>`"/opt/iar/cxarm/common/bin/ninja"` |
 
 During the configuration phase, CMake reads these variables from:
 - a separate file called "toolchain file" that you invoke `cmake` with `--toolchain /path/to/<filename>.cmake` (see provided example files [bxarm.cmake](tutorial/bxarm.cmake) and [ewarm.cmake](tutorial/ewarm.cmake)) -or-
@@ -108,11 +108,11 @@ enable_testing()
 - Then use [`add_test()`](https://cmake.org/cmake/help/latest/command/add_test.html#add-test) to encapsulate the command line `cspybat` needs. In the example below, the parameters are adjusted for simulating a generic Arm Cortex-M4 target environment:
 ```cmake
 add_test(NAME tutorialTest
-         COMMAND /opt/iarsystems/bxarm/common/bin/CSpyBat
+         COMMAND /opt/iar/cxarm/common/bin/CSpyBat
          # C-SPY drivers for the Arm simulator via command line interface
-         /opt/iarsystems/bxarm/arm/bin/libarmPROC.so
-         /opt/iarsystems/bxarm/arm/bin/libarmSIM2.so
-         --plugin=/opt/iarsystems/bxarm/arm/bin/libarmLibsupportUniversal.so
+         /opt/iar/cxarm/arm/bin/libarmPROC.so
+         /opt/iar/cxarm/arm/bin/libarmSIM2.so
+         --plugin=/opt/iar/cxarm/arm/bin/libarmLibsupportUniversal.so
          # The target executable (built with debug information)
          --debug_file=$<TARGET_FILE:tutorial>
          # C-SPY driver options

--- a/examples/libs/CMakeLists.txt
+++ b/examples/libs/CMakeLists.txt
@@ -21,11 +21,11 @@ target_link_options(libs PRIVATE
 enable_testing()
 
 add_test(NAME libs-test
-         COMMAND /opt/iarsystems/bxarm/common/bin/CSpyBat
+         COMMAND /opt/iar/cxarm/common/bin/CSpyBat
          # C-SPY drivers for the Arm simulator via command line interface
-         /opt/iarsystems/bxarm/arm/bin/libarmPROC.so
-         /opt/iarsystems/bxarm/arm/bin/libarmSIM2.so
-         --plugin=/opt/iarsystems/bxarm/arm/bin/libarmLibsupportUniversal.so
+         /opt/iar/cxarm/arm/bin/libarmPROC.so
+         /opt/iar/cxarm/arm/bin/libarmSIM2.so
+         --plugin=/opt/iar/cxarm/arm/bin/libarmLibsupportUniversal.so
          # The target executable (built with debug information)
          --debug_file=$<TARGET_FILE:libs>
          # C-SPY driver options

--- a/examples/mix/CMakeLists.txt
+++ b/examples/mix/CMakeLists.txt
@@ -17,11 +17,11 @@ target_link_options(mix PRIVATE
 enable_testing()
 
 add_test(NAME mix-test
-         COMMAND /opt/iarsystems/bxarm/common/bin/CSpyBat
+         COMMAND /opt/iar/cxarm/common/bin/CSpyBat
          # C-SPY drivers for the Arm simulator via command line interface
-         /opt/iarsystems/bxarm/arm/bin/libarmPROC.so
-         /opt/iarsystems/bxarm/arm/bin/libarmSIM2.so
-         --plugin=/opt/iarsystems/bxarm/arm/bin/libarmLibsupportUniversal.so
+         /opt/iar/cxarm/arm/bin/libarmPROC.so
+         /opt/iar/cxarm/arm/bin/libarmSIM2.so
+         --plugin=/opt/iar/cxarm/arm/bin/libarmLibsupportUniversal.so
          # The target executable (built with debug information)
          --debug_file=$<TARGET_FILE:mix>
          # C-SPY driver options

--- a/examples/version/CMakeLists.txt
+++ b/examples/version/CMakeLists.txt
@@ -22,11 +22,11 @@ target_link_options(version PRIVATE
 enable_testing()
 
 add_test(NAME version-test
-         COMMAND /opt/iarsystems/bxarm/common/bin/CSpyBat
+         COMMAND /opt/iar/cxarm/common/bin/CSpyBat
          # C-SPY drivers for the Arm simulator via command line interface
-         /opt/iarsystems/bxarm/arm/bin/libarmPROC.so
-         /opt/iarsystems/bxarm/arm/bin/libarmSIM2.so
-         --plugin=/opt/iarsystems/bxarm/arm/bin/libarmLibsupportUniversal.so
+         /opt/iar/cxarm/arm/bin/libarmPROC.so
+         /opt/iar/cxarm/arm/bin/libarmSIM2.so
+         --plugin=/opt/iar/cxarm/arm/bin/libarmLibsupportUniversal.so
          # The target executable (built with debug information)
          --debug_file=$<TARGET_FILE:version>
          # C-SPY driver options

--- a/tutorial/bxarm.cmake
+++ b/tutorial/bxarm.cmake
@@ -5,9 +5,9 @@ set(CMAKE_SYSTEM_NAME Generic)
 
 # Set CMake to use the IAR C/C++ Compiler from the IAR Build Tools for Arm
 # Update if using a different supported target or operating system
-set(CMAKE_ASM_COMPILER /opt/iarsystems/bxarm/arm/bin/iasmarm)
-set(CMAKE_C_COMPILER   /opt/iarsystems/bxarm/arm/bin/iccarm)
-set(CMAKE_CXX_COMPILER /opt/iarsystems/bxarm/arm/bin/iccarm)
+set(CMAKE_ASM_COMPILER /opt/iar/cxarm/arm/bin/iasmarm)
+set(CMAKE_C_COMPILER   /opt/iar/cxarm/arm/bin/iccarm)
+set(CMAKE_CXX_COMPILER /opt/iar/cxarm/arm/bin/iccarm)
 
 # Avoids running the linker during try_compile()
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
@@ -21,7 +21,7 @@ if(CMAKE_GENERATOR MATCHES "^Ninja.*$")
   find_program(CMAKE_MAKE_PROGRAM
     NAMES ninja
     PATHS $ENV{PATH}
-          /opt/iarsystems/bxarm/common/bin
+          /opt/iar/cxarm/common/bin
     REQUIRED)
 endif()
 


### PR DESCRIPTION
This pull request includes updates to the CI workflow and modifications to various files to change the paths of the IAR toolchain from `bxarm` to `cxarm`. The most important changes include adding a new CI workflow, updating the README with new paths, and modifying CMake files to reflect the new toolchain paths.

### CI Workflow Addition:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R25): Added a new Continuous Integration workflow that runs on self-hosted runners and includes steps for checking the compiler license and version, and running CMake commands.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R66): Updated the paths for `CMAKE_C_COMPILER`, `CMAKE_CXX_COMPILER`, `CMAKE_ASM_COMPILER`, and `CMAKE_MAKE_PROGRAM` to use the new `cxarm` directory. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R66) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L111-R115)

### CMake Configuration Updates:
* [`examples/libs/CMakeLists.txt`](diffhunk://#diff-26efe4681eeedfd7b642c9c1bb7707d8898de4f5f333caf6f44b66ffe6c1c895L24-R28): Updated the paths for C-SPY drivers and plugins to use the new `cxarm` directory.
* [`examples/mix/CMakeLists.txt`](diffhunk://#diff-e45305375a9237c702103d2c909e8b913727e24a8adc671043cb33b7c7ea1064L20-R24): Updated the paths for C-SPY drivers and plugins to use the new `cxarm` directory.
* [`examples/version/CMakeLists.txt`](diffhunk://#diff-05d2834f042fecbbcac5737835c7215d6539ba5211ead4b88567d07140b95fe4L25-R29): Updated the paths for C-SPY drivers and plugins to use the new `cxarm` directory.
* [`tutorial/bxarm.cmake`](diffhunk://#diff-f8606cb46978479a8872609258debfe5f2eb0359b46cbad443e5df0d94920f26L8-R10): Updated the paths for ASM, C, and C++ compilers, and the make program to use the new `cxarm` directory. [[1]](diffhunk://#diff-f8606cb46978479a8872609258debfe5f2eb0359b46cbad443e5df0d94920f26L8-R10) [[2]](diffhunk://#diff-f8606cb46978479a8872609258debfe5f2eb0359b46cbad443e5df0d94920f26L24-R24)