### PR TITLE
Artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,9 @@ jobs:
           cmake --build .
         name: Run CMAKE
         working-directory: ./tutorial
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            tutorial/build/**/*


### PR DESCRIPTION
This pull request includes an update to the CI workflow to improve artifact handling by uploading build artifacts after the CMake build step.

Changes to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR26-R31): Added a step to use `actions/upload-artifact@v4` to upload build artifacts from the `tutorial/build` directory.